### PR TITLE
Implement onEventBlockRemoved.

### DIFF
--- a/src/main/java/org/konstructs/flowers/FlowersPlugin.java
+++ b/src/main/java/org/konstructs/flowers/FlowersPlugin.java
@@ -80,6 +80,8 @@ public class FlowersPlugin extends KonstructsActor {
         }
     }
 
+    @Override
+    public void onEventBlockRemoved(EventBlockRemoved block) {}
 
     @Override
     public void onReceive(Object message) {


### PR DESCRIPTION
The logs where spammed with "called onEventBlockRemoved: not
implemented"
